### PR TITLE
Added performance tests and significantly improved performance

### DIFF
--- a/cassette/__init__.py
+++ b/cassette/__init__.py
@@ -22,6 +22,11 @@ def insert(filename):
 
 def eject():
     """Remove cassette, unpatching HTTP requests."""
+    # If the cassette items have changed, save the changes to file
+    if cassette_library.is_dirty:
+        cassette_library.write_to_file()
+
+    # Remove our overrides
     unpatch()
 
 

--- a/cassette/http_response.py
+++ b/cassette/http_response.py
@@ -50,5 +50,9 @@ class MockedHTTPResponse(MockedResponse):
     def getheader(self, name):
         return self.headers[name]
 
+    def rewind(self):
+        self.fp = StringIO(unicode(self.content, "utf-8"))
+        return self
+
     def close(self):
         pass

--- a/cassette/tests/test_cassette.py
+++ b/cassette/tests/test_cassette.py
@@ -190,7 +190,7 @@ class TestCassette(TestCase):
 
         # First run
         cassette.insert(TEMPORARY_RESPONSES_FILENAME)
-        r = urllib2.urlopen(TEST_URL)
+        r = urllib2.urlopen(TEST_URL + '?manual')
         cassette.eject()
 
         self.assertEqual(self.had_response.called, False)
@@ -200,7 +200,7 @@ class TestCassette(TestCase):
 
         # Second run
         cassette.insert(TEMPORARY_RESPONSES_FILENAME)
-        r = urllib2.urlopen(TEST_URL)
+        r = urllib2.urlopen(TEST_URL + '?manual')
         cassette.eject()
 
         self.assertEqual(self.had_response.called, True)

--- a/cassette/tests/test_cassette_performance.py
+++ b/cassette/tests/test_cassette_performance.py
@@ -1,0 +1,65 @@
+import urllib2
+import cassette
+import os
+from datetime import datetime, timedelta
+from cassette.tests.base import TestCase
+
+TEST_URL = "http://127.0.0.1:5000/non-ascii-content"
+CASSETTE_FILENAME = './cassette/tests/data/performance.yaml'
+
+
+class TestCassettePerformance(TestCase):
+    @classmethod
+    def teardown_class(cls):
+        if os.path.exists(CASSETTE_FILENAME):
+            os.remove(CASSETTE_FILENAME)
+
+    def generate_large_cassette(self):
+        # Record every next request
+        cassette.insert(CASSETTE_FILENAME)
+
+        # Create 100 requests to load in
+        for i in range(0, 100):
+            url = '%s?%s' % (TEST_URL, i)
+            urllib2.urlopen(url).read()
+
+        # Write out to files
+        cassette.eject()
+
+    def test_generate_speed(self):
+        # Record how long it takes for the generation to take place
+        start_time = datetime.now()
+        self.generate_large_cassette()
+        stop_time = datetime.now()
+
+        # Verify the file generates in under 2 seconds
+        two_seconds = timedelta(seconds=2)
+        self.assertLess(stop_time - start_time, two_seconds)
+
+    def fetch_frequent_cassette(self):
+        # 100 times in a row
+        for i in range(0, 100):
+            # Open cassette
+            cassette.insert(CASSETTE_FILENAME)
+
+            # Make a few requests
+            for j in range(0, 5):
+                url = '%s?%s' % (TEST_URL, j)
+                urllib2.urlopen(url).read()
+
+            # Close cassette
+            cassette.eject()
+
+    def test_fetch_speed(self):
+        # Guarantee there is a large cassette to test against
+        if not os.path.exists(CASSETTE_FILENAME):
+            self.generate_large_cassette()
+
+        # Record how long it takes to fetch from a file frequently
+        start_time = datetime.now()
+        self.fetch_frequent_cassette()
+        stop_time = datetime.now()
+
+        # Verify the frequent fetches can run in under 2 seconds
+        two_seconds = timedelta(seconds=2)
+        self.assertLess(stop_time - start_time, two_seconds)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,4 @@ nose
 flake8
 flask
 sphinx==1.2b1
-pyroma==0.6c11
 zest.releaser==3.44


### PR DESCRIPTION
The initial performance results were:

```
Time spent generate: 0:00:19.827882
Time spent fetching: 0:00:55.469668
```

They are now down to:

```
Time spent generate: 0:00:00.590623
Time spent fetching: 0:00:00.742201
```
