### PR TITLE
Fixing bad URL inside of test suite

### DIFF
--- a/cassette/tests/test_cassette.py
+++ b/cassette/tests/test_cassette.py
@@ -229,7 +229,7 @@ class TestCassette(TestCase):
             "param": "1",
         }
 
-        url = "/get?"
+        url = "get?"
         url += _encode_params(param)
         r = self.check_urllib2_flow(url=url)
         self.assertEqual(r.json["args"]["param"], "1")


### PR DESCRIPTION
Ran tests locally and discovered that we were requesting `//get?int=1&array=item1&array=item2&dict1=dict4&dict1=dict2&param=1`. This should get the test suite back to running.
