### PR TITLE
Remove the 'Host' header from the hash to make hostname/port changes easier

### DIFF
--- a/cassette/cassette_library.py
+++ b/cassette/cassette_library.py
@@ -30,6 +30,11 @@ class CassetteName(unicode):
         """Create an object from an httplib request."""
 
         if headers:
+            if 'Host' in headers:
+                # 'Host' is already covered explicitly below, remove from the
+                # hash so hostname/post are easy to change and sed the file
+                del headers['Host']
+
             headers = hashlib.md5(repr(sorted(headers.items()))).hexdigest()
 
         if will_hash_body:

--- a/cassette/tests/data/responses.yaml
+++ b/cassette/tests/data/responses.yaml
@@ -1,58 +1,58 @@
-httplib:GET 127.0.0.1:5000/headers 3410f218eb8e0894b4d8d0380dc9c427 None:
+httplib:GET 127.0.0.1:5000/headers 917ed38bcb583a67c891f9fa59792bc0 None:
   content: "{\n  \"json\": true\n}"
-  headers: {content-length: '18', content-type: application/json, date: 'Mon, 17 Mar
-      2014 18:05:07 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+  headers: {content-length: '18', content-type: application/json, date: 'Mon, 16 Jun
+      2014 18:55:54 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: application/json\r\n", "Content-Length: 18\r\n", "Server:\
-      \ Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:07 GMT\r\n"]
+      \ Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54 GMT\r\n"]
   reason: OK
   status: 200
-httplib:GET 127.0.0.1:5000/headers ff46c364f1879735fb09bfbc967f1eb7 None:
+httplib:GET 127.0.0.1:5000/headers c2585c6aafb8fa06dc8bb6de88f9de0b None:
   content: not json
   headers: {content-length: '8', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:07 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+      16 Jun 2014 18:55:54 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 8\r\
-      \n", "Server: Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:07\
+      \n", "Server: Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54\
       \ GMT\r\n"]
   reason: OK
   status: 200
 httplib:GET 127.0.0.1:5000/index None None:
   content: hello world
   headers: {content-length: '11', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:06 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+      16 Jun 2014 18:55:53 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 11\r\
-      \n", "Server: Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:06\
+      \n", "Server: Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:53\
       \ GMT\r\n"]
   reason: OK
   status: 200
-httplib:GET 127.0.0.1:5000/index ff46c364f1879735fb09bfbc967f1eb7 None:
+httplib:GET 127.0.0.1:5000/index c2585c6aafb8fa06dc8bb6de88f9de0b None:
   content: hello world
   headers: {content-length: '11', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:06 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+      16 Jun 2014 18:55:54 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 11\r\
-      \n", "Server: Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:06\
+      \n", "Server: Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54\
       \ GMT\r\n"]
   reason: OK
   status: 200
-httplib:GET 127.0.0.1:5000/non-ascii-content ff46c364f1879735fb09bfbc967f1eb7 None:
+httplib:GET 127.0.0.1:5000/non-ascii-content c2585c6aafb8fa06dc8bb6de88f9de0b None:
   content: !!python/str "Le Mexicain l'avait achet\xE9e en viager \xE0 un procureur\
     \ \xE0 la retraite. Apr\xE8s trois mois, l'accident b\xEAte. Une affaire."
   headers: {content-length: '120', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:06 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+      16 Jun 2014 18:55:54 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 120\r\
-      \n", "Server: Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:06\
+      \n", "Server: Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54\
       \ GMT\r\n"]
   reason: OK
   status: 200
-httplib:GET 127.0.0.1:5000/redirected ff46c364f1879735fb09bfbc967f1eb7 None:
+httplib:GET 127.0.0.1:5000/redirected c2585c6aafb8fa06dc8bb6de88f9de0b None:
   content: hello world redirected
   headers: {content-length: '22', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:07 GMT', server: Werkzeug/0.9.4 Python/2.7.6}
+      16 Jun 2014 18:55:54 GMT', server: Werkzeug/0.9.6 Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 22\r\
-      \n", "Server: Werkzeug/0.9.4 Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:07\
+      \n", "Server: Werkzeug/0.9.6 Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54\
       \ GMT\r\n"]
   reason: OK
   status: 200
-httplib:GET 127.0.0.1:5000/will_redirect ff46c364f1879735fb09bfbc967f1eb7 None:
+httplib:GET 127.0.0.1:5000/will_redirect c2585c6aafb8fa06dc8bb6de88f9de0b None:
   content: '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 
     <title>Redirecting...</title>
@@ -62,19 +62,19 @@ httplib:GET 127.0.0.1:5000/will_redirect ff46c364f1879735fb09bfbc967f1eb7 None:
     <p>You should be redirected automatically to target URL: <a href="/redirected">/redirected</a>.  If
     not click the link.'
   headers: {content-length: '229', content-type: text/html; charset=utf-8, date: 'Mon,
-      17 Mar 2014 18:05:07 GMT', location: 'http://127.0.0.1:5000/redirected', server: Werkzeug/0.9.4
-      Python/2.7.6}
+      16 Jun 2014 18:55:54 GMT', location: 'http://127.0.0.1:5000/redirected', server: Werkzeug/0.9.6
+      Python/2.7.2}
   raw_headers: ["Content-Type: text/html; charset=utf-8\r\n", "Content-Length: 229\r\
-      \n", "Location: http://127.0.0.1:5000/redirected\r\n", "Server: Werkzeug/0.9.4\
-      \ Python/2.7.6\r\n", "Date: Mon, 17 Mar 2014 18:05:07 GMT\r\n"]
+      \n", "Location: http://127.0.0.1:5000/redirected\r\n", "Server: Werkzeug/0.9.6\
+      \ Python/2.7.2\r\n", "Date: Mon, 16 Jun 2014 18:55:54 GMT\r\n"]
   reason: FOUND
   status: 302
-httplib:GET httpbin.org:443/ip feaa75537257c5171f84863afd99dabe None:
-  content: "{\n  \"origin\": \"4.53.137.10\"\n}"
-  headers: {access-control-allow-origin: '*', connection: Close, content-length: '29',
-    content-type: application/json, date: 'Mon, 17 Mar 2014 18:05:05 GMT', server: gunicorn/0.17.4}
+httplib:GET httpbin.org:443/ip c2585c6aafb8fa06dc8bb6de88f9de0b None:
+  content: "{\n  \"origin\": \"8.26.157.128\"\n}"
+  headers: {access-control-allow-origin: '*', connection: Close, content-length: '30',
+    content-type: application/json, date: 'Mon, 16 Jun 2014 18:55:50 GMT', server: gunicorn/18.0}
   raw_headers: ["Access-Control-Allow-Origin: *\r\n", "Content-Type: application/json\r\
-      \n", "Date: Mon, 17 Mar 2014 18:05:05 GMT\r\n", "Server: gunicorn/0.17.4\r\n",
-    "Content-Length: 29\r\n", "Connection: Close\r\n"]
+      \n", "Date: Mon, 16 Jun 2014 18:55:50 GMT\r\n", "Server: gunicorn/18.0\r\n",
+    "Content-Length: 30\r\n", "Connection: Close\r\n"]
   reason: OK
   status: 200


### PR DESCRIPTION
It is not uncommon for port or entire hostnames to change as configurations vary over time. Since these values are included in the hash it is impossible to manually edit the yaml file to make said adjustment.

Since the host and port is already captured in the request schema, remove it from considering for the hash.
