### PR TITLE
introduce the concept of backfire

### DIFF
--- a/cassette/__init__.py
+++ b/cassette/__init__.py
@@ -38,3 +38,10 @@ def play(filename, file_format=''):
     insert(filename, file_format=file_format)
     yield
     eject()
+
+
+@contextlib.contextmanager
+def backfire():
+    patch(None, backfire=True)
+    yield
+    unpatch()

--- a/cassette/patcher.py
+++ b/cassette/patcher.py
@@ -9,18 +9,37 @@ unpatched_HTTPConnection = httplib.HTTPConnection
 unpatched_HTTPSConnection = httplib.HTTPSConnection
 
 
-def patch(cassette_library):
+class AttemptedConnection(Exception):
+    pass
+
+
+def _raise_attempted_connection(*args, **kwargs):
+    # If you are seeing this exception, one of your colleagues has kindly
+    # requested that you do not attempt to utilize HTTP requests during the
+    # running of this area of your tests.  Consider refactoring the code you
+    # want to test so that the logic can be tested independently from the I/O,
+    # in a unit level test.
+
+    raise AttemptedConnection()
+
+
+def patch(cassette_library, backfire=False):
     """Replace standard library."""
 
     # Inspired by vcrpy
 
+    connection = CassetteHTTPConnection
+
+    if backfire:
+        connection = _raise_attempted_connection
+
     CassetteHTTPConnection._cassette_library = cassette_library
     CassetteHTTPSConnection._cassette_library = cassette_library
 
-    httplib.HTTPConnection = CassetteHTTPConnection
-    httplib.HTTP._connection_class = CassetteHTTPConnection
-    httplib.HTTPSConnection = CassetteHTTPSConnection
-    httplib.HTTPS._connection_class = CassetteHTTPSConnection
+    httplib.HTTPConnection = connection
+    httplib.HTTP._connection_class = connection
+    httplib.HTTPSConnection = connection
+    httplib.HTTPS._connection_class = connection
 
 
 def unpatch():


### PR DESCRIPTION
The idea here is to have a strategy for moving away from integration tests. When mocking is done via cassette as it is currently designed, we are left with a lot of work to pass the tests each time we change what is being requested from a dependent service to another service. By using "backfire", we can start to slowly and methodically remove HTTP dependencies from our tests, and move towards a unit-test only mindset.

At the end of the day, the data coming over the wire must be allowed to be malleable. We can't code our tests against old data.
