### PR TITLE
introduce ensure_no_http_requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,13 @@ Cassette stores and replays HTTP requests made in your Python app.
 
     assert "A.ROOT-SERVERS.NET" in r.read(10000)
 
+    # Similarly, you can use cassette to prevent HTTP requests from being made
+    # from your code.
+    with cassette.ensure_no_http_requests():
+        # The next line will cause an AttemptedConnectionException to be thrown
+        r = urllib2.urlopen("http://www.internic.net/domain/named.root")
+
+
 Installation
 ------------
 

--- a/cassette/__init__.py
+++ b/cassette/__init__.py
@@ -38,3 +38,11 @@ def play(filename, file_format=''):
     insert(filename, file_format=file_format)
     yield
     eject()
+
+
+@contextlib.contextmanager
+def ensure_no_http_requests():
+    """Prevent code from making outbound HTTP requests."""
+    patch(None, ensure_no_http_requests=True)
+    yield
+    unpatch()

--- a/cassette/patcher.py
+++ b/cassette/patcher.py
@@ -9,18 +9,32 @@ unpatched_HTTPConnection = httplib.HTTPConnection
 unpatched_HTTPSConnection = httplib.HTTPSConnection
 
 
-def patch(cassette_library):
+class AttemptedConnectionException(Exception):
+    """Thrown when an HTTP request is attempted."""
+    pass
+
+
+def _raise_attempted_connection_exception(*args, **kwargs):
+    raise AttemptedConnectionException()
+
+
+def patch(cassette_library, ensure_no_http_requests=False):
     """Replace standard library."""
 
     # Inspired by vcrpy
 
+    connection = CassetteHTTPConnection
+
+    if ensure_no_http_requests:
+        connection = _raise_attempted_connection_exception
+
     CassetteHTTPConnection._cassette_library = cassette_library
     CassetteHTTPSConnection._cassette_library = cassette_library
 
-    httplib.HTTPConnection = CassetteHTTPConnection
-    httplib.HTTP._connection_class = CassetteHTTPConnection
-    httplib.HTTPSConnection = CassetteHTTPSConnection
-    httplib.HTTPS._connection_class = CassetteHTTPSConnection
+    httplib.HTTPConnection = connection
+    httplib.HTTP._connection_class = connection
+    httplib.HTTPSConnection = connection
+    httplib.HTTPS._connection_class = connection
 
 
 def unpatch():

--- a/cassette/tests/data/responses.yaml
+++ b/cassette/tests/data/responses.yaml
@@ -78,3 +78,14 @@ httplib:GET httpbin.org:443/ip c2585c6aafb8fa06dc8bb6de88f9de0b None:
     "Content-Length: 30\r\n", "Connection: Close\r\n"]
   reason: OK
   status: 200
+httplib:GET httpbin.org:80/ip c2585c6aafb8fa06dc8bb6de88f9de0b None:
+  content: "{\n  \"origin\": \"173.13.150.22\"\n}"
+  headers: {access-control-allow-credentials: 'true', access-control-allow-origin: '*',
+    connection: Close, content-length: '31', content-type: application/json, date: 'Thu,
+      24 Jul 2014 18:08:55 GMT', server: gunicorn/18.0}
+  raw_headers: ["Access-Control-Allow-Credentials: true\r\n", "Access-Control-Allow-Origin:\
+      \ *\r\n", "Content-Type: application/json\r\n", "Date: Thu, 24 Jul 2014 18:08:55\
+      \ GMT\r\n", "Server: gunicorn/18.0\r\n", "Content-Length: 31\r\n", "Connection:\
+      \ Close\r\n"]
+  reason: OK
+  status: 200

--- a/cassette/tests/test_cassette.py
+++ b/cassette/tests/test_cassette.py
@@ -18,6 +18,7 @@ from cassette.cassette_library import CassetteLibrary
 from cassette.tests.base import (TEMPORARY_RESPONSES_DIRECTORY,
                                  TEMPORARY_RESPONSES_FILENAME, TestCase)
 from cassette.tests.server.run import app
+from cassette.patcher import AttemptedConnectionException
 
 RESPONSES_FILENAME = "./cassette/tests/data/responses.yaml"
 IMAGE_FILENAME = "./cassette/tests/server/image.png"
@@ -292,6 +293,21 @@ class TestCassette(TestCase):
         self.assertEqual(self.had_response.called, True)
 
 
+class TestCassetteEnsureNoHTTPRequests(TestCassette):
+    def test_ensure_no_http_requests(self):
+        with cassette.ensure_no_http_requests():
+            try:
+                request = urllib2.Request('http://example.com/', headers={})
+                urllib2.urlopen(request)
+            except AttemptedConnectionException:
+                return
+            except Exception, e:
+                print e
+                pass
+
+        self.assertEqual(False, True)
+
+
 class TestCassetteJson(TestCassette):
     """Perform the same test but in JSON."""
 
@@ -428,7 +444,8 @@ class TestCassetteFile(TestCase):
 
     def test_redirects(self):
         """Verify that cassette can handle a redirect."""
-        self.check_read_from_file_flow(TEST_URL_REDIRECT, "hello world redirected")
+        self.check_read_from_file_flow(TEST_URL_REDIRECT,
+                                       "hello world redirected")
 
     def test_non_ascii_content(self):
         """Verify that cassette can handle non-ascii content."""

--- a/fabfile.py
+++ b/fabfile.py
@@ -12,7 +12,7 @@ def test(args=""):
 
     print green("\nRunning tests")
 
-    local("flake8 --ignore=E501,E702 .")
+    local("flake8 --ignore=E501,E702 --exclude=env .")
     local("nosetests %s" % args)
 
 


### PR DESCRIPTION
Allow users to prevent HTTP requests in their tests. One use case is to force mocking of data in tests, instead of relying on external servers or services.
