### PR TITLE
Fix HTTP Response to use cStringIO, adding Unicode support.

### DIFF
--- a/cassette/http_response.py
+++ b/cassette/http_response.py
@@ -1,3 +1,4 @@
+import cStringIO
 import io
 from httplib import HTTPMessage
 
@@ -52,7 +53,7 @@ class MockedHTTPResponse(MockedResponse):
     def create_file_descriptor(content):
         """Create a file descriptor for content."""
 
-        fp = io.BytesIO(content)
+        fp = cStringIO.StringIO(content)
 
         return fp
 


### PR DESCRIPTION
Change http_response's create_file_descriptor to get unicode support, avoiding tests failing when reading from Cassette at:

env/local/lib/python2.7/site-packages/cassette/http_response.py:55: in create_file_descriptor
    fp = io.BytesIO(content)
E   TypeError: 'unicode' does not have the buffer interface
