### PR TITLE
Fix NameError when using UL3CassetteHTTPConnection when undefined in req...

### DIFF
--- a/cassette/http_connection.py
+++ b/cassette/http_connection.py
@@ -36,9 +36,12 @@ class CassetteConnectionMixin(object):
             #
             # TODO: If we're going to add more adaptors to this module, this
             # class shouldn't know anything about its parent classes.
-            if (isinstance(self, UL3CassetteHTTPConnection) and
-                    hasattr(self, 'sock')):
-                del self.sock
+            try:
+                if (isinstance(self, UL3CassetteHTTPConnection) and
+                        hasattr(self, 'sock')):
+                    del self.sock
+            except NameError:
+                pass
 
             return
 


### PR DESCRIPTION
Putting a part of request() in a try-catch, avoiding a NameError to break certain projects using Cassette.
