### PR TITLE
Fixed IP range expectations for tests

### DIFF
--- a/cassette/tests/test_cassette.py
+++ b/cassette/tests/test_cassette.py
@@ -318,7 +318,10 @@ class TestCassette(TestCase):
     def test_requestslib_https(self):
         """Test that HTTPS requests work using requests."""
         resp = self.helper_requestslib(TEST_URL_HTTPS)
-        assert resp.headers['content-length'] == '30'
+        # len('{\n  "origin":"0.0.0.0"\n}')  # 24
+        assert int(resp.headers['content-length']) >= 24
+        # len('{\n  "origin":  "255.255.255.255"\n}')  # 34
+        assert int(resp.headers['content-length']) <= 34
         assert 'origin' in resp.json()
 
     def test_requestslib_redir(self):


### PR DESCRIPTION
I am currently debugging issues with `requests==2.5.1`. However, during debugging I noticed that the tests on `master` were failing locally. It looks like we were assuming a specific IP value for the `test_requestslib_https` test.

To remedy this, we have changed the assertions to verify the `content-length` is within the smallest and largest possible IP values. In this PR:

- Updated `test_requestslib_https` to assert against minimum/maximum IP values `0.0.0.0`/`255.255.255.255`