### PR TITLE
support the new kwarg in HTTPSConnection in 2.7.9+ and 3.4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ python:
     - "2.7"
 install:
     - "pip install -r requirements.txt -r requirements-dev.txt --use-mirrors"
-script: "py.test"
+script: "py.test cassette"

--- a/cassette/patcher.py
+++ b/cassette/patcher.py
@@ -16,6 +16,9 @@ from cassette.http_connection import (CassetteHTTPConnection,
 
 unpatched_HTTPConnection = httplib.HTTPConnection
 unpatched_HTTPSConnection = httplib.HTTPSConnection
+if requests:
+    unpatched_requests_HTTPConnection = requests.packages.urllib3.connection.HTTPConnection
+    unpatched_requests_HTTPSConnection = requests.packages.urllib3.connection.HTTPSConnection
 
 
 def patch(cassette_library):
@@ -53,6 +56,6 @@ def unpatch():
 
     if requests:
         requests.packages.urllib3.connection.HTTPConnection = \
-            unpatched_HTTPConnection
+            unpatched_requests_HTTPConnection
         requests.packages.urllib3.connection.HTTPSConnection = \
-            unpatched_HTTPSConnection
+            unpatched_requests_HTTPSConnection


### PR DESCRIPTION
Fixes failures trying to patch urllib2.urlopen on versions of Python that support SSL Contexts.