### PR TITLE
fix tests on requests <2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML>=3.10
+semver>=2.0


### PR DESCRIPTION
Alternatively, we could just require requests >= 2.4.0. That would rule out a lot of internal consumers, though.